### PR TITLE
:sparkles: feat(CRFs): Add HITS screening and Brief Danger Assessment…

### DIFF
--- a/flourish_visit_schedule/visit_schedules/crfs/caregiver_crfs.py
+++ b/flourish_visit_schedule/visit_schedules/crfs/caregiver_crfs.py
@@ -85,6 +85,8 @@ a_crf_2000 = FormsCollection(
     Crf(show_order=30, model='flourish_caregiver.tbreferralcaregiver'),
     Crf(show_order=31, model='flourish_caregiver.caregivertbreferraloutcome',
         required=False),
+    Crf(show_order=32, model='flourish_caregiver.hitsscreening'),
+    Crf(show_order=33, model='flourish_caregiver.briefdangerassessment', required=False),
     name='cohort_a_enrollment')
 
 bc_crf_2000 = FormsCollection(
@@ -123,6 +125,8 @@ bc_crf_2000 = FormsCollection(
     Crf(show_order=21, model='flourish_caregiver.caregivertbreferraloutcome',
         required=False),
     Crf(show_order=22, model='flourish_caregiver.maternalarvadherence', required=False),
+    Crf(show_order=23, model='flourish_caregiver.hitsscreening'),
+    Crf(show_order=24, model='flourish_caregiver.briefdangerassessment', required=False),
     name='cohort_bc_enrollment')
 
 crf_2000d = FormsCollection(
@@ -186,6 +190,8 @@ crf_2001 = FormsCollection(
     Crf(show_order=20, model='flourish_caregiver.tbreferralcaregiver'),
     Crf(show_order=21, model='flourish_caregiver.caregivertbreferraloutcome',
         required=False),
+    Crf(show_order=22, model='flourish_caregiver.hitsscreening'),
+    Crf(show_order=23, model='flourish_caregiver.briefdangerassessment', required=False),
     name='quarterly_calls')
 
 a_crf_3000 = FormsCollection(
@@ -224,6 +230,8 @@ a_crf_3000 = FormsCollection(
     Crf(show_order=22, model='flourish_caregiver.tbreferralcaregiver'),
     Crf(show_order=23, model='flourish_caregiver.caregivertbreferraloutcome',
         required=False),
+    Crf(show_order=24, model='flourish_caregiver.hitsscreening'),
+    Crf(show_order=25, model='flourish_caregiver.briefdangerassessment', required=False),
     name='a_follow_up')
 
 b_crf_3000 = FormsCollection(
@@ -264,6 +272,8 @@ b_crf_3000 = FormsCollection(
     Crf(show_order=23, model='flourish_caregiver.tbreferralcaregiver'),
     Crf(show_order=24, model='flourish_caregiver.caregivertbreferraloutcome',
         required=False),
+    Crf(show_order=25, model='flourish_caregiver.hitsscreening'),
+    Crf(show_order=26, model='flourish_caregiver.briefdangerassessment', required=False),
     name='b_follow_up')
 
 c_crf_3000 = FormsCollection(
@@ -303,6 +313,8 @@ c_crf_3000 = FormsCollection(
     Crf(show_order=22, model='flourish_caregiver.tbreferralcaregiver'),
     Crf(show_order=23, model='flourish_caregiver.caregivertbreferraloutcome',
         required=False),
+    Crf(show_order=24, model='flourish_caregiver.hitsscreening'),
+    Crf(show_order=25, model='flourish_caregiver.briefdangerassessment', required=False),
     name='c_follow_up')
 
 tb_2_months = FormsCollection(


### PR DESCRIPTION
… forms

These changes include the addition of HITS screening and Brief Danger Assessment forms to flourish_caregiver. This has been achieved by creating models for each form in the app models and creating corresponding forms, admin interfaces, and updating the form mixins. In addition, the maternal visit form has been updated to include these new forms. These changes are necessary to expand the functionality of the app and provide more comprehensive data collection features for users. The reference model configs for HITS screening and metadata rules have also been updated to accommodate these changes.