### PR TITLE
(feature): Add childhood lead exposure risk rule function



### DIFF
--- a/flourish_visit_schedule/visit_schedules/crfs/child_crfs.py
+++ b/flourish_visit_schedule/visit_schedules/crfs/child_crfs.py
@@ -140,6 +140,7 @@ child_a_crf_2001 = FormsCollection(
     Crf(show_order=27, model='flourish_child.childtbreferral', required=False),
     Crf(show_order=28, model='flourish_child.childtbreferraloutcome', required=False),
     Crf(show_order=29, model='flourish_child.childcliniciannotes', required=False),
+    Crf(show_order=30, model='flourish_child.childhoodleadexposurerisk', required=False),
     name='child_quarterly_calls')
 
 child_b_crf_2001 = FormsCollection(
@@ -204,6 +205,7 @@ child_a_crf_3000 = FormsCollection(
     Crf(show_order=19, model='flourish_child.childtbreferral', required=False),
     Crf(show_order=20, model='flourish_child.childtbreferraloutcome', required=False),
     Crf(show_order=21, model='flourish_child.childsafistigma', required=False),
+    Crf(show_order=22, model='flourish_child.childhoodleadexposurerisk'),
     name='child_a_follow_up')
 
 child_b_crf_3000 = FormsCollection(


### PR DESCRIPTION
This update includes the addition of a rule function 'func_childhood_lead_exposure_risk_required' to the child_predicates.py file and a 'childhood_lead_exposure_risk' rule to the child_visit_rules.py file. The function checks if there's a need for a childhood lead exposure risk assessment during follow-up visits, and the rule enforces this condition. Signed-off-by: nmunatsibw 