### PR TITLE
(feature): Add childhood lead exposure risk rule function

### DIFF
--- a/flourish_visit_schedule/visit_schedules/crfs/caregiver_crfs.py
+++ b/flourish_visit_schedule/visit_schedules/crfs/caregiver_crfs.py
@@ -194,6 +194,8 @@ crf_2001 = FormsCollection(
         required=False),
     Crf(show_order=22, model='flourish_caregiver.parentadolrelationshipscale', required=False),
     Crf(show_order=23, model='flourish_caregiver.cliniciannotes', required=False),
+    Crf(show_order=34, model='flourish_caregiver.childhoodleadexposurerisk',
+        required=False),
     name='quarterly_calls')
 
 a_crf_3000 = FormsCollection(
@@ -236,6 +238,7 @@ a_crf_3000 = FormsCollection(
     Crf(show_order=26, model='flourish_caregiver.briefdangerassessment', required=False),
     Crf(show_order=27, model='flourish_caregiver.caregiversafistigma', ),
     Crf(show_order=28, model='flourish_caregiver.caregivercageaid'),
+    Crf(show_order=29, model='flourish_caregiver.childhoodleadexposurerisk'),
     name='a_follow_up')
 
 b_crf_3000 = FormsCollection(

--- a/flourish_visit_schedule/visit_schedules/crfs/child_crfs.py
+++ b/flourish_visit_schedule/visit_schedules/crfs/child_crfs.py
@@ -140,6 +140,7 @@ child_a_crf_2001 = FormsCollection(
     Crf(show_order=30, model='flourish_child.childtbscreening', required=False),
     Crf(show_order=31, model='flourish_child.childtbreferral'),
     Crf(show_order=32, model='flourish_child.childtbreferraloutcome', required=False),
+    Crf(show_order=33, model='flourish_child.childhoodleadexposurerisk', required=False),
     name='child_quarterly_calls')
 
 child_b_crf_2001 = FormsCollection(
@@ -201,6 +202,7 @@ child_a_crf_3000 = FormsCollection(
     Crf(show_order=19, model='flourish_child.childtbreferral', required=False),
     Crf(show_order=20, model='flourish_child.childtbreferraloutcome', required=False),
     Crf(show_order=21, model='flourish_child.childsafistigma', required=False),
+    Crf(show_order=22, model='flourish_child.childhoodleadexposurerisk'),
     name='child_a_follow_up')
 
 child_b_crf_3000 = FormsCollection(

--- a/flourish_visit_schedule/visit_schedules/crfs/child_crfs.py
+++ b/flourish_visit_schedule/visit_schedules/crfs/child_crfs.py
@@ -138,10 +138,10 @@ child_a_crf_2001 = FormsCollection(
     Crf(show_order=28, model='flourish_child.infanthivtesting9months', required=False),
     Crf(show_order=29, model='flourish_child.infantarvprophylaxis',
         required=False),
-    Crf(show_order=30, model='flourish_child.childtbscreening', required=False),
-    Crf(show_order=31, model='flourish_child.childtbreferral'),
+    Crf(show_order=30, model='flourish_child.childtbscreening',),
+    Crf(show_order=31, model='flourish_child.childtbreferral', required=False),
     Crf(show_order=32, model='flourish_child.childtbreferraloutcome', required=False),
-    Crf(show_order=33, model='flourish_child.childhoodleadexposurerisk', required=False),
+    Crf(show_order=33, model='flourish_child.childcliniciannotes', required=False),
     name='child_quarterly_calls')
 
 child_b_crf_2001 = FormsCollection(
@@ -203,7 +203,6 @@ child_a_crf_3000 = FormsCollection(
     Crf(show_order=19, model='flourish_child.childtbreferral', required=False),
     Crf(show_order=20, model='flourish_child.childtbreferraloutcome', required=False),
     Crf(show_order=21, model='flourish_child.childsafistigma', required=False),
-    Crf(show_order=22, model='flourish_child.childhoodleadexposurerisk'),
     name='child_a_follow_up')
 
 child_b_crf_3000 = FormsCollection(


### PR DESCRIPTION
This update includes the addition of a rule function 'func_childhood_lead_exposure_risk_required' to the child_predicates.py file and a 'childhood_lead_exposure_risk' rule to the child_visit_rules.py file. The function checks if there's a need for a childhood lead exposure risk assessment during follow-up visits, and the rule enforces this condition.